### PR TITLE
feat: add precommithook for conventional commit enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,24 +76,10 @@ A PowerShell-based Git commit-msg hook is available at `git/hooks/commit-msg.ps1
 
 ### Installation
 
-Copy the hook script to your repository's `.git/hooks` directory (without the `.ps1` extension or wrapped in a shell script that calls PowerShell):
+Copy the hook script to your repository's `.git/hooks` directory (if you are using linux or macOS: copy it without the `.ps1` extension or wrap it in a shell script that calls PowerShell):
 
-**Option 1: Direct copy (requires Git to execute PowerShell scripts)**
+**On macOS and Linux you have to make the file executable after copiying:**
 ```bash
-cp git/hooks/commit-msg.ps1 .git/hooks/commit-msg
-chmod +x .git/hooks/commit-msg
-```
-
-**Option 2: Create a wrapper script (cross-platform)**
-```bash
-# Create .git/hooks/commit-msg with the following content:
-#!/bin/sh
-exec pwsh -NoProfile -File "$(dirname "$0")/commit-msg.ps1" "$1"
-```
-
-Then copy the PowerShell script:
-```bash
-cp git/hooks/commit-msg.ps1 .git/hooks/
 chmod +x .git/hooks/commit-msg
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A PowerShell-based Git commit-msg hook is available at `git/hooks/commit-msg.ps1
 
 Copy the hook script to your repository's `.git/hooks` directory (if you are using linux or macOS: copy it without the `.ps1` extension or wrap it in a shell script that calls PowerShell):
 
-**On macOS and Linux you have to make the file executable after copiying:**
+**On macOS and Linux you have to make the file executable after copying:**
 ```bash
 chmod +x .git/hooks/commit-msg
 ```

--- a/README.md
+++ b/README.md
@@ -69,3 +69,75 @@ The workflow inspects the latest commit message and applies the following preced
 If no existing tags matching `v*` are found, versioning starts from `0.0.0`.
 
 Each run also publishes (or updates) a Git tag matching the new version. By default tags look like `vX.Y.Z`, but you can provide a `prefix` input (for example `license-module`) to emit tags such as `license-module-vX.Y.Z`. The workflow creates a GitHub release with auto-generated release notes for the generated tag. Existing tags or releases are detected and left untouched.
+
+## Commit message hook
+
+A PowerShell-based Git commit-msg hook is available at `git/hooks/commit-msg.ps1` to enforce the [Conventional Commits](https://www.conventionalcommits.org/) standard locally before commits are created.
+
+### Installation
+
+Copy the hook script to your repository's `.git/hooks` directory (without the `.ps1` extension or wrapped in a shell script that calls PowerShell):
+
+**Option 1: Direct copy (requires Git to execute PowerShell scripts)**
+```bash
+cp git/hooks/commit-msg.ps1 .git/hooks/commit-msg
+chmod +x .git/hooks/commit-msg
+```
+
+**Option 2: Create a wrapper script (cross-platform)**
+```bash
+# Create .git/hooks/commit-msg with the following content:
+#!/bin/sh
+exec pwsh -NoProfile -File "$(dirname "$0")/commit-msg.ps1" "$1"
+```
+
+Then copy the PowerShell script:
+```bash
+cp git/hooks/commit-msg.ps1 .git/hooks/
+chmod +x .git/hooks/commit-msg
+```
+
+### What it validates
+
+The hook validates that commit messages follow the Conventional Commits format:
+
+```
+<type>[optional scope][optional !]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+#### Valid types
+
+| Type | Description |
+|------|-------------|
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation only changes |
+| `style` | Code style changes (formatting, missing semicolons, etc.) |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf` | Performance improvements |
+| `test` | Adding or correcting tests |
+| `build` | Changes to build system or dependencies |
+| `ci` | Changes to CI configuration files and scripts |
+| `chore` | Other changes that don't modify src or test files |
+| `revert` | Reverts a previous commit |
+| `deps` | Dependency updates |
+
+#### Examples
+
+```
+feat: add user authentication
+fix(api): resolve null reference exception
+feat(auth)!: change login flow (breaking change)
+docs: update README with setup instructions
+```
+
+### Warnings
+
+The hook will display warnings (but not reject the commit) for:
+
+- **Long subject lines**: Subject lines longer than 72 characters
+- **Missing breaking change documentation**: When `!` is used but no `BREAKING CHANGE:` section is present in the body

--- a/git/hooks/commit-msg.ps1
+++ b/git/hooks/commit-msg.ps1
@@ -1,0 +1,88 @@
+# Conventional Commits validation hook
+# This hook validates commit messages according to https://www.conventionalcommits.org/
+
+$commitMsgFile = $args[0]
+
+try {
+    $commitMsg = Get-Content $commitMsgFile -Raw -ErrorAction Stop
+} catch {
+    Write-Host "Error: Could not read commit message file" -ForegroundColor Red
+    exit 1
+}
+
+# Remove comments and trim
+$commitMsg = ($commitMsg -split "`n" | Where-Object { $_ -notmatch '^\s*#' }) -join "`n"
+$commitMsg = $commitMsg.Trim()
+
+if ([string]::IsNullOrWhiteSpace($commitMsg)) {
+    Write-Host "Error: Commit message is empty" -ForegroundColor Red
+    exit 1
+}
+
+# Get the first line (subject)
+$subject = ($commitMsg -split "`n")[0]
+
+# Conventional Commits regex pattern
+# Format: type(scope)!: description
+# - type: required (feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert)
+# - scope: optional
+# - !: optional (indicates breaking change)
+# - description: required
+$pattern = '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|deps)(\([a-z0-9\-\/]+\))?(!)?: .{1,}'
+
+if ($subject -notmatch $pattern) {
+    Write-Host ""
+    Write-Host "❌ COMMIT REJECTED: Invalid commit message format" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Your commit message:" -ForegroundColor Yellow
+    Write-Host "  $subject" -ForegroundColor White
+    Write-Host ""
+    Write-Host "Conventional Commits format required:" -ForegroundColor Cyan
+    Write-Host "  <type>[optional scope][optional !]: <description>" -ForegroundColor White
+    Write-Host ""
+    Write-Host "Valid types:" -ForegroundColor Cyan
+    Write-Host "  feat:     A new feature" -ForegroundColor White
+    Write-Host "  fix:      A bug fix" -ForegroundColor White
+    Write-Host "  docs:     Documentation only changes" -ForegroundColor White
+    Write-Host "  style:    Code style changes (formatting, missing semi colons, etc)" -ForegroundColor White
+    Write-Host "  refactor: Code change that neither fixes a bug nor adds a feature" -ForegroundColor White
+    Write-Host "  perf:     Performance improvements" -ForegroundColor White
+    Write-Host "  test:     Adding or correcting tests" -ForegroundColor White
+    Write-Host "  build:    Changes to build system or dependencies" -ForegroundColor White
+    Write-Host "  ci:       Changes to CI configuration files and scripts" -ForegroundColor White
+    Write-Host "  chore:    Other changes that don't modify src or test files" -ForegroundColor White
+    Write-Host "  revert:   Reverts a previous commit" -ForegroundColor White
+    Write-Host ""
+    Write-Host "Examples:" -ForegroundColor Cyan
+    Write-Host "  feat: add user authentication" -ForegroundColor Green
+    Write-Host "  fix(api): resolve null reference exception" -ForegroundColor Green
+    Write-Host "  feat(auth)!: change login flow (breaking change)" -ForegroundColor Green
+    Write-Host "  docs: update README with setup instructions" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "For more information, visit: https://www.conventionalcommits.org/" -ForegroundColor Cyan
+    Write-Host ""
+    exit 1
+}
+
+# Check subject length (recommended max 72 characters for subject)
+if ($subject.Length -gt 72) {
+    Write-Host ""
+    Write-Host "⚠️  WARNING: Commit subject is longer than 72 characters ($($subject.Length) chars)" -ForegroundColor Yellow
+    Write-Host "Consider shortening the description or moving details to the body." -ForegroundColor Yellow
+    Write-Host ""
+    # This is just a warning, not rejecting the commit
+}
+
+# Optional: Check for body format if breaking change indicator is present
+if ($subject -match '!:' -or $commitMsg -match 'BREAKING CHANGE:') {
+    if ($commitMsg -notmatch 'BREAKING CHANGE:') {
+        Write-Host ""
+        Write-Host "⚠️  WARNING: Breaking change indicator (!) found but no 'BREAKING CHANGE:' in body" -ForegroundColor Yellow
+        Write-Host "Consider adding a 'BREAKING CHANGE: <description>' section in the commit body." -ForegroundColor Yellow
+        Write-Host ""
+        # This is just a warning, not rejecting the commit
+    }
+}
+
+Write-Host "✅ Commit message follows Conventional Commits format" -ForegroundColor Green
+exit 0

--- a/git/hooks/commit-msg.ps1
+++ b/git/hooks/commit-msg.ps1
@@ -28,7 +28,7 @@ $subject = ($commitMsg -split "`n")[0]
 # - scope: optional
 # - !: optional (indicates breaking change)
 # - description: required
-$pattern = '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|deps)(\([a-z0-9\-\/]+\))?(!)?: .{1,}'
+$pattern = '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|deps)(\([a-z0-9\-\/]+\))?(!)?: \S.{0,}'
 
 if ($subject -notmatch $pattern) {
     Write-Host ""

--- a/git/hooks/commit-msg.ps1
+++ b/git/hooks/commit-msg.ps1
@@ -44,7 +44,7 @@ if ($subject -notmatch $pattern) {
     Write-Host "  feat:     A new feature" -ForegroundColor White
     Write-Host "  fix:      A bug fix" -ForegroundColor White
     Write-Host "  docs:     Documentation only changes" -ForegroundColor White
-    Write-Host "  style:    Code style changes (formatting, missing semi colons, etc)" -ForegroundColor White
+    Write-Host "  style:    Code style changes (formatting, missing semicolons, etc.)" -ForegroundColor White
     Write-Host "  refactor: Code change that neither fixes a bug nor adds a feature" -ForegroundColor White
     Write-Host "  perf:     Performance improvements" -ForegroundColor White
     Write-Host "  test:     Adding or correcting tests" -ForegroundColor White

--- a/git/hooks/commit-msg.ps1
+++ b/git/hooks/commit-msg.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 # Conventional Commits validation hook
 # This hook validates commit messages according to https://www.conventionalcommits.org/
 


### PR DESCRIPTION
closes #4 
This pull request introduces a new PowerShell commit message hook to enforce the Conventional Commits standard for commit messages. The script validates the commit message format, provides clear error and warning messages, and educates users about the required structure and valid types. This helps maintain consistent and meaningful commit history across the project.

Commit message validation and guidance:

* Added `git/hooks/commit-msg.ps1` script to validate commit messages against the Conventional Commits specification, rejecting non-compliant messages and providing detailed feedback and examples.
* Displays warnings if the commit subject exceeds 72 characters or if a breaking change indicator is present without a corresponding body section, helping users follow best practices.