### PR TITLE
fix: enhance release notification highlights extraction logic

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -145,11 +145,24 @@ jobs:
               }
             }
 
-            const bulletLike = (sectionLines.length ? sectionLines : lines)
+            const sectionBullets = (sectionLines.length ? sectionLines : [])
               .filter(l => /^[-*•]\s+/.test(l) || /^\d+\.\s+/.test(l))
               .filter(l => !/full\s+changelog/i.test(l));
-            const pick = (bulletLike.length ? bulletLike : (sectionLines.length ? sectionLines : lines).filter(l => !/full\s+changelog/i.test(l)))
-              .slice(0, maxHighlights);
+            const globalBullets = lines
+              .filter(l => /^[-*•]\s+/.test(l) || /^\d+\.\s+/.test(l))
+              .filter(l => !/full\s+changelog/i.test(l));
+            let pick;
+            if (headingIndex >= 0 && sectionLines.length && sectionBullets.length) {
+              // "What's Changed" section exists and has bullets: use only those bullets
+              pick = sectionBullets.slice(0, maxHighlights);
+            } else if (globalBullets.length) {
+              // Fall back to bullets from the whole body
+              pick = globalBullets.slice(0, maxHighlights);
+            } else {
+              // No bullets at all: fall back to first non-empty, non-"full changelog" lines globally
+              const fallbackLines = lines.filter(l => !/full\s+changelog/i.test(l));
+              pick = fallbackLines.slice(0, maxHighlights);
+            }
 
             const highlightsText = pick.length
               ? pick.map(l => {

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -131,12 +131,25 @@ jobs:
             const body = (rel.body || '').trim();
 
             // Strategy:
-            // 1) If release body has bullet-ish lines, take first N bullet lines as highlights
-            // 2) Else take first N non-empty lines (trimmed) as highlights
+            // 1) If a "What's Changed" section exists, use only bullets from that section
+            // 2) Else fall back to first N bullet-ish lines, or first N non-empty lines
             const lines = body.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+            const headingIndex = lines.findIndex(l => /^#{1,6}\s+what'?s changed\b/i.test(l));
+            let sectionLines = [];
+            if (headingIndex >= 0) {
+              const targetLevel = lines[headingIndex].match(/^#+/)[0].length;
+              for (let i = headingIndex + 1; i < lines.length; i++) {
+                const headingMatch = lines[i].match(/^#+/);
+                if (headingMatch && headingMatch[0].length <= targetLevel) break;
+                sectionLines.push(lines[i]);
+              }
+            }
 
-            const bulletLike = lines.filter(l => /^[-*•]\s+/.test(l) || /^\d+\.\s+/.test(l));
-            const pick = (bulletLike.length ? bulletLike : lines).slice(0, maxHighlights);
+            const bulletLike = (sectionLines.length ? sectionLines : lines)
+              .filter(l => /^[-*•]\s+/.test(l) || /^\d+\.\s+/.test(l))
+              .filter(l => !/full\s+changelog/i.test(l));
+            const pick = (bulletLike.length ? bulletLike : (sectionLines.length ? sectionLines : lines).filter(l => !/full\s+changelog/i.test(l)))
+              .slice(0, maxHighlights);
 
             const highlightsText = pick.length
               ? pick.map(l => {
@@ -149,18 +162,11 @@ jobs:
             // Summary: first sentence-ish or first line
             const summary = lines[0] ? (lines[0].length > 180 ? lines[0].slice(0, 177) + '…' : lines[0]) : 'New release published.';
 
-            // Try to extract version from tag if it contains vX.Y.Z...
-            const versionMatch = tag.match(/v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/);
-            const version = versionMatch ? versionMatch[1] : '';
-
             const payload = {
-              title: `Release published: ${name}`,
-              repository: `${owner}/${repo}`,
+              title: `${isPrerelease ? 'Pre-Release' : 'Release'} published: ${name}`,
               release: {
                 name,
                 tag,
-                version,
-                isPrerelease,
                 publishedAt,
                 url
               },


### PR DESCRIPTION
This pull request updates the release notification workflow to improve how highlights are extracted from release notes and refines the notification payload. The main changes focus on making the highlight extraction more accurate by prioritizing the "What's Changed" section and cleaning up the payload structure.

**Release highlight extraction improvements:**

* The workflow now looks specifically for a "What's Changed" section in the release notes and extracts only bullet points from that section as highlights. If the section is missing, it falls back to the previous logic of using the first bullet-like or non-empty lines. This ensures that the most relevant changes are highlighted in notifications.

**Notification payload adjustments:**

* The notification title now distinguishes between pre-releases and regular releases by prefixing with "Pre-Release" or "Release" accordingly.
* The `version` and `isPrerelease` fields are removed from the `release` object in the payload, streamlining the data sent to the notification endpoint.