### PR TITLE
fix: remove tagMatch from epoch semver workflow

### DIFF
--- a/.github/workflows/epoch-semver-version.yml
+++ b/.github/workflows/epoch-semver-version.yml
@@ -95,7 +95,7 @@ jobs:
           }
 
           # Get all tags matching the pattern, sorted by version descending
-          $tagOutput = git tag -l $tagMatch --sort=-version:refname
+          $tagOutput = git tag -l --sort=-version:refname
           $allTags = @($tagOutput | Where-Object { $_ })
 
           Write-Host "Debug info:"

--- a/.github/workflows/epoch-semver-version.yml
+++ b/.github/workflows/epoch-semver-version.yml
@@ -98,10 +98,6 @@ jobs:
           $tagOutput = git tag -l --sort=-version:refname
           $allTags = @($tagOutput | Where-Object { $_ })
 
-          Write-Host "Debug info:"
-          Write-Host $allTags
-          Write-Host "tagMatch: $tagMatch"
-
           # Find the last stable version (no prerelease identifier)
           $lastStableTag = ''
           $lastStableYear = 0
@@ -124,17 +120,12 @@ jobs:
               }
             }
           }
-          Write-Host "Last stable tag: $lastStableTag"
-
 
           # Determine which commits to check based on mode
           $logLimit = $checkLastCommitOnly ? @('-1') : @()
           $logRange = $lastStableTag ? @("$lastStableTag..HEAD") : @()
           $commitSubjects = @(git log @logLimit --pretty=%s @logRange)
           $commitSubjects = @($commitSubjects | Where-Object { $_ })
-
-          Write-Host "Commit subjects:"
-          Write-Host $commitSubjects
 
           # Scan commits for bump level: release patterns (BREAKING CHANGE:, feat:, <any>!:) vs patch
           $releasePattern = '^\S*!:'
@@ -170,8 +161,6 @@ jobs:
 
           # Determine version
           $sameEpoch = $lastStableTag -and ($currentYear -le $lastStableYear) -and ($currentWeek -le $lastStableWeek)
-          Write-Host "Same epoch: $sameEpoch (current: $currentYear-W$currentWeek, last stable: $lastStableYear-W$lastStableWeek)"
-
 
           if ($isBreakingChangeOrFeature -and -not $sameEpoch) {
             $newYear = $currentYear
@@ -186,7 +175,6 @@ jobs:
           }
 
           $targetBaseVersion = "$newYear.$newWeek.$newPatch"
-          Write-Host "Target base version: $targetBaseVersion"
 
           # Find the last prerelease for this target base version and name
           $lastPrereleaseTag = ''
@@ -216,7 +204,6 @@ jobs:
           }
 
           $newTag = "${prefixWithDash}v${newVersion}"
-          Write-Host "New version: $newVersion, new tag: $newTag"
 
           # Write outputs
           "bump_type=$bumpType" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/epoch-semver-version.yml
+++ b/.github/workflows/epoch-semver-version.yml
@@ -98,6 +98,10 @@ jobs:
           $tagOutput = git tag -l $tagMatch --sort=-version:refname
           $allTags = @($tagOutput | Where-Object { $_ })
 
+          Write-Host "Debug info:"
+          Write-Host $allTags
+          Write-Host "tagMatch: $tagMatch"
+
           # Find the last stable version (no prerelease identifier)
           $lastStableTag = ''
           $lastStableYear = 0
@@ -120,12 +124,17 @@ jobs:
               }
             }
           }
+          Write-Host "Last stable tag: $lastStableTag"
+
 
           # Determine which commits to check based on mode
           $logLimit = $checkLastCommitOnly ? @('-1') : @()
           $logRange = $lastStableTag ? @("$lastStableTag..HEAD") : @()
           $commitSubjects = @(git log @logLimit --pretty=%s @logRange)
           $commitSubjects = @($commitSubjects | Where-Object { $_ })
+
+          Write-Host "Commit subjects:"
+          Write-Host $commitSubjects
 
           # Scan commits for bump level: release patterns (BREAKING CHANGE:, feat:, <any>!:) vs patch
           $releasePattern = '^\S*!:'
@@ -161,6 +170,8 @@ jobs:
 
           # Determine version
           $sameEpoch = $lastStableTag -and ($currentYear -le $lastStableYear) -and ($currentWeek -le $lastStableWeek)
+          Write-Host "Same epoch: $sameEpoch (current: $currentYear-W$currentWeek, last stable: $lastStableYear-W$lastStableWeek)"
+
 
           if ($isBreakingChangeOrFeature -and -not $sameEpoch) {
             $newYear = $currentYear
@@ -175,6 +186,7 @@ jobs:
           }
 
           $targetBaseVersion = "$newYear.$newWeek.$newPatch"
+          Write-Host "Target base version: $targetBaseVersion"
 
           # Find the last prerelease for this target base version and name
           $lastPrereleaseTag = ''
@@ -204,6 +216,7 @@ jobs:
           }
 
           $newTag = "${prefixWithDash}v${newVersion}"
+          Write-Host "New version: $newVersion, new tag: $newTag"
 
           # Write outputs
           "bump_type=$bumpType" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for semantic versioning. The change simplifies the `git tag` command by removing the `$tagMatch` filter, which means it will now list all tags (not just those matching a specific pattern) sorted by version in descending order.

* Simplified the `git tag` command in `.github/workflows/epoch-semver-version.yml` to list all tags in descending version order, removing the `$tagMatch` filter.