### PR TITLE
feat!: add draft release possibility epoch semver

### DIFF
--- a/.github/workflows/epoch-semver-version.yml
+++ b/.github/workflows/epoch-semver-version.yml
@@ -34,7 +34,7 @@ on:
         type: boolean
         default: false
       prerelease_name:
-        description: "Name for prerelease identifier (e.g., 'prerelease', 'rc', 'alpha')"
+        description: "Name for prerelease identifier. Set to an empty string to keep plain epoch semver versions and active prerelease state."
         required: false
         type: string
         default: "prerelease"
@@ -90,6 +90,7 @@ jobs:
           $checkLastCommitOnly = $env:CHECK_LAST_COMMIT_ONLY -eq 'true'
           $isPrerelease = $env:IS_PRERELEASE -eq 'true'
           $prereleaseName = ($env:PRERELEASE_NAME) ?? 'prerelease'
+          $hasPrereleaseSuffix = -not [string]::IsNullOrWhiteSpace($prereleaseName)
 
           if ($prefix) {
             $tagMatch = "$prefix-v*"
@@ -185,7 +186,7 @@ jobs:
           $lastPrereleaseTag = ''
           $lastPrereleaseVersion = 0
 
-          if ($isPrerelease) {
+          if ($isPrerelease -and $hasPrereleaseSuffix) {
             $escapedName = [regex]::Escape($prereleaseName)
             foreach ($tag in $allTags) {
               $strippedTag = $tag -replace "^$([regex]::Escape($prefixWithDash))", ''
@@ -199,7 +200,7 @@ jobs:
           }
 
           # Build the final version string and determine changelog base tag
-          if ($isPrerelease) {
+          if ($isPrerelease -and $hasPrereleaseSuffix) {
             $prereleaseVersion = $lastPrereleaseVersion + 1
             $newVersion = "$newYear.$newWeek.$newPatch-$prereleaseName.$prereleaseVersion"
             $changelogBaseTag = $lastPrereleaseTag ? $lastPrereleaseTag : $lastStableTag

--- a/.github/workflows/epoch-semver-version.yml
+++ b/.github/workflows/epoch-semver-version.yml
@@ -287,15 +287,31 @@ jobs:
             exit 0
           }
 
-          Write-Host (
-            $env:CHANGELOG_BASE_TAG
-            ? "Generating release notes from $($env:CHANGELOG_BASE_TAG) to $($env:TAG_NAME)"
-            : "Generating release notes from initial commit to $($env:TAG_NAME)"
+          if ($env:CHANGELOG_BASE_TAG) {
+            Write-Host "Generating release notes from $($env:CHANGELOG_BASE_TAG) to $($env:TAG_NAME)"
+          } else {
+            Write-Host "Generating release notes from initial commit to $($env:TAG_NAME)"
+          }
+
+          $releaseCreateArguments = @(
+            'release', 'create', $env:TAG_NAME,
+            '--title', $env:TAG_NAME,
+            '--target', $env:GITHUB_SHA,
+            '--generate-notes'
           )
 
-          gh release create $env:TAG_NAME --title $env:TAG_NAME --target $env:GITHUB_SHA --generate-notes `
-            $($env:IS_PRERELEASE -eq 'true' ? @('--prerelease') : @()) `
-            $($env:IS_DRAFT_RELEASE -eq 'true' ? @('--draft') : @()) `
-            $($env:CHANGELOG_BASE_TAG ? @('--notes-start-tag', $env:CHANGELOG_BASE_TAG) : @())
+          if ($env:IS_PRERELEASE -eq 'true') {
+            $releaseCreateArguments += '--prerelease'
+          }
+
+          if ($env:IS_DRAFT_RELEASE -eq 'true') {
+            $releaseCreateArguments += '--draft'
+          }
+
+          if ($env:CHANGELOG_BASE_TAG) {
+            $releaseCreateArguments += @('--notes-start-tag', $env:CHANGELOG_BASE_TAG)
+          }
+
+          gh @releaseCreateArguments
           if ($LASTEXITCODE -ne 0) { throw 'Failed to create release' }
           Write-Host "Created release $($env:TAG_NAME)"

--- a/.github/workflows/epoch-semver-version.yml
+++ b/.github/workflows/epoch-semver-version.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      is_draft_release:
+        description: "If true, create the GitHub release as a draft"
+        required: false
+        type: boolean
+        default: false
       suppress_tag:
         description: "If true, skip creating a Git tag and release"
         required: false
@@ -271,6 +276,7 @@ jobs:
           CHANGELOG_BASE_TAG: ${{ steps.compute.outputs.previous_tag_for_changelog }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
+          IS_DRAFT_RELEASE: ${{ inputs.is_draft_release }}
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -289,6 +295,7 @@ jobs:
 
           gh release create $env:TAG_NAME --title $env:TAG_NAME --target $env:GITHUB_SHA --generate-notes `
             $($env:IS_PRERELEASE -eq 'true' ? @('--prerelease') : @()) `
+            $($env:IS_DRAFT_RELEASE -eq 'true' ? @('--draft') : @()) `
             $($env:CHANGELOG_BASE_TAG ? @('--notes-start-tag', $env:CHANGELOG_BASE_TAG) : @())
           if ($LASTEXITCODE -ne 0) { throw 'Failed to create release' }
           Write-Host "Created release $($env:TAG_NAME)"

--- a/.github/workflows/epoch-semver-version.yml
+++ b/.github/workflows/epoch-semver-version.yml
@@ -54,6 +54,9 @@ on:
       commit_subject:
         description: "Commit subject that drove the bump decision"
         value: ${{ jobs.bump.outputs.commit_subject }}
+      release_type:
+        description: "Release type resolved from inputs (release, prerelease, draft)"
+        value: ${{ jobs.bump.outputs.release_type }}
 
 jobs:
   bump:
@@ -69,6 +72,7 @@ jobs:
       previous_tag: ${{ steps.compute.outputs.previous_tag }}
       previous_tag_for_changelog: ${{ steps.compute.outputs.previous_tag_for_changelog }}
       commit_subject: ${{ steps.compute.outputs.commit_subject }}
+      release_type: ${{ steps.compute.outputs.release_type }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -81,6 +85,7 @@ jobs:
           PREFIX: ${{ inputs.prefix }}
           CHECK_LAST_COMMIT_ONLY: ${{ inputs.check_last_commit_only }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
+          IS_DRAFT_RELEASE: ${{ inputs.is_draft_release }}
           PRERELEASE_NAME: ${{ inputs.prerelease_name }}
         shell: pwsh
         run: |
@@ -89,8 +94,17 @@ jobs:
           $prefix = $env:PREFIX
           $checkLastCommitOnly = $env:CHECK_LAST_COMMIT_ONLY -eq 'true'
           $isPrerelease = $env:IS_PRERELEASE -eq 'true'
+          $isDraftRelease = $env:IS_DRAFT_RELEASE -eq 'true'
           $prereleaseName = ($env:PRERELEASE_NAME) ?? 'prerelease'
           $hasPrereleaseSuffix = -not [string]::IsNullOrWhiteSpace($prereleaseName)
+
+          if ($isDraftRelease) {
+            $releaseType = 'draft'
+          } elseif ($isPrerelease) {
+            $releaseType = 'prerelease'
+          } else {
+            $releaseType = 'release'
+          }
 
           if ($prefix) {
             $tagMatch = "$prefix-v*"
@@ -218,6 +232,7 @@ jobs:
           "version=$newVersion" >> $env:GITHUB_OUTPUT
           "tag=$newTag" >> $env:GITHUB_OUTPUT
           "commit_subject=$commitSubject" >> $env:GITHUB_OUTPUT
+          "release_type=$releaseType" >> $env:GITHUB_OUTPUT
 
           Write-Host "Determined $bumpType bump from '$commitSubject' -> $newTag"
           Write-Host "Changelog will be generated from: $($changelogBaseTag ? $changelogBaseTag : 'initial commit')"
@@ -230,6 +245,7 @@ jobs:
           BUMP_TYPE: ${{ steps.compute.outputs.bump_type }}
           PREVIOUS_TAG: ${{ steps.compute.outputs.previous_tag }}
           COMMIT_SUBJECT: ${{ steps.compute.outputs.commit_subject }}
+          RELEASE_TYPE: ${{ steps.compute.outputs.release_type }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -242,6 +258,7 @@ jobs:
             "- Version: ``$($env:VERSION)``"
             "- Tag: ``$($env:TAG)``"
             "- Bump type: ``$($env:BUMP_TYPE)``"
+            "- Release type: ``$($env:RELEASE_TYPE)``"
             "- Previous tag: ``$previous``"
             "- Commit: $commit"
           ) -join "`n" >> $env:GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ jobs:
           echo "Version: ${{ needs.version.outputs.version }}"
           echo "Tag:     ${{ needs.version.outputs.tag }}"
           echo "Bump:    ${{ needs.version.outputs.bump_type }}"
+          echo "Type:    ${{ needs.version.outputs.release_type }}"
           echo "Prev tag:${{ needs.version.outputs.previous_tag }}"
           echo "Commit:  ${{ needs.version.outputs.commit_subject }}"
 ```
@@ -190,6 +191,7 @@ jobs:
 - `version` – The calculated semantic version (for example `2026.8.2`).
 - `tag` – The tag name that would be created (for example `v2026.8.2` or `module-v2026.8.2`).
 - `bump_type` – The bump classification applied (`release` or `patch`).
+- `release_type` – The resolved release type from flags (`release`, `prerelease`, or `draft`). When both draft and prerelease are set, `draft` wins.
 - `previous_tag` – The most recent matching tag prior to this run, if any.
 - `commit_subject` – The commit message subject that determined the bump decision.
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ jobs:
     with:
       prefix: license-module # optional: prefix for tags like license-module-vX.Y.Z
       suppress_release: false # optional: set true to skip creating a GitHub release
+      is_draft_release: false # optional: set true to create a draft GitHub release
       suppress_tag: false # optional: set true to skip both tag and release creation
       check_last_commit_only: false # optional: set true to only inspect the latest commit
       is_prerelease: false # optional: set true to generate a prerelease version
@@ -178,6 +179,7 @@ jobs:
 
 - `prefix` _(string, default: empty)_ – Optional prefix prepended to generated tags (for example `license-module-vYYYY.WW.P`).
 - `suppress_release` _(boolean, default: false)_ – When `true`, skips creating a GitHub release while still creating tags (unless suppressed below).
+- `is_draft_release` _(boolean, default: false)_ – When `true`, creates the GitHub release as a draft.
 - `suppress_tag` _(boolean, default: false)_ – When `true`, skips creating both the Git tag and the GitHub release.
 - `check_last_commit_only` _(boolean, default: false)_ – When `true`, only the most recent commit is inspected to determine the bump type instead of all commits since the previous tag.
 - `is_prerelease` _(boolean, default: false)_ – When `true`, generates a prerelease version (for example `v2026.8.2-rc.1`).

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ jobs:
       suppress_tag: false # optional: set true to skip both tag and release creation
       check_last_commit_only: false # optional: set true to only inspect the latest commit
       is_prerelease: false # optional: set true to generate a prerelease version
-      prerelease_name: prerelease # optional: name for prerelease identifier (e.g., 'rc', 'alpha', 'beta')
+      prerelease_name: prerelease # optional: name for prerelease identifier (e.g., 'rc', 'alpha', 'beta'); set to "" to keep plain epoch semver version while still marking the GitHub release as prerelease
 
   publish:
     runs-on: ubuntu-latest
@@ -182,8 +182,8 @@ jobs:
 - `is_draft_release` _(boolean, default: false)_ – When `true`, creates the GitHub release as a draft.
 - `suppress_tag` _(boolean, default: false)_ – When `true`, skips creating both the Git tag and the GitHub release.
 - `check_last_commit_only` _(boolean, default: false)_ – When `true`, only the most recent commit is inspected to determine the bump type instead of all commits since the previous tag.
-- `is_prerelease` _(boolean, default: false)_ – When `true`, generates a prerelease version (for example `v2026.8.2-rc.1`).
-- `prerelease_name` _(string, default: "prerelease")_ – Name for the prerelease identifier (for example `rc`, `alpha`, `beta`).
+- `is_prerelease` _(boolean, default: false)_ – When `true`, marks the GitHub release as prerelease and generates a prerelease version suffix unless `prerelease_name` is set to an empty string.
+- `prerelease_name` _(string, default: "prerelease")_ – Name for the prerelease identifier (for example `rc`, `alpha`, `beta`). Set it to an empty string to keep plain epoch semver version format (for example `v2026.8.2`) while still creating a prerelease release.
 
 ### Outputs <a name="epoch_semantic_outputs" id="epoch_semantic_outputs"></a>
 


### PR DESCRIPTION
This pull request enhances the GitHub Actions workflow for semantic versioning by adding support for draft releases, improving prerelease handling, and updating documentation for clarity. The main improvements are the introduction of an `is_draft_release` input, refined logic for prerelease naming and versioning, and clearer documentation about these behaviors.

**Workflow and Release Creation Enhancements:**

* Added a new `is_draft_release` input to `.github/workflows/epoch-semver-version.yml`, allowing releases to be created as drafts when specified. [[1]](diffhunk://#diff-0df8ab77360d7adc1fe61109d2fbdb013e4af20aa81b9d728d2af602d4918f2bR16-R20) [[2]](diffhunk://#diff-0df8ab77360d7adc1fe61109d2fbdb013e4af20aa81b9d728d2af602d4918f2bR280) [[3]](diffhunk://#diff-0df8ab77360d7adc1fe61109d2fbdb013e4af20aa81b9d728d2af602d4918f2bL284-R316)
* Refined prerelease logic so that if `prerelease_name` is empty, the workflow produces a plain epoch semver version but still marks the release as a prerelease if requested. [[1]](diffhunk://#diff-0df8ab77360d7adc1fe61109d2fbdb013e4af20aa81b9d728d2af602d4918f2bL32-R37) [[2]](diffhunk://#diff-0df8ab77360d7adc1fe61109d2fbdb013e4af20aa81b9d728d2af602d4918f2bR93) [[3]](diffhunk://#diff-0df8ab77360d7adc1fe61109d2fbdb013e4af20aa81b9d728d2af602d4918f2bL183-R189) [[4]](diffhunk://#diff-0df8ab77360d7adc1fe61109d2fbdb013e4af20aa81b9d728d2af602d4918f2bL197-R203)

**Documentation Updates:**

* Updated `README.md` to document the new `is_draft_release` input and clarified the behavior of `prerelease_name` and `is_prerelease`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R154-R158) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R182-R186)

These changes make the release workflow more flexible and transparent, especially for projects that require draft or prerelease workflows.